### PR TITLE
Changes the fatalError to assertionFailure

### DIFF
--- a/Swen/Classes/Swen.swift
+++ b/Swen/Classes/Swen.swift
@@ -181,7 +181,8 @@ fileprivate class EventListener<EventType: BaseEvent> {
 
     func post(_ event: EventType) {
         guard let _ = observer else {
-            fatalError("One of the observers did not unregister, but already dealocated, observer info: " + eventClassName)
+            assertionFailure("One of the observers did not unregister, but already dealocated, observer info: " + eventClassName)
+            return
         }
 
         if OperationQueue.current == queue {


### PR DESCRIPTION
- In my opinion the fatalError should be an assertionFailure, since the observer has been deallocated and therefore a fatalError hurts the user experience.
- This way it only exits in development